### PR TITLE
Fix EBS volume tagging for cost tracking

### DIFF
--- a/align/serverless.yml
+++ b/align/serverless.yml
@@ -49,6 +49,33 @@ resources:
 
   Resources:
 
+    AlignmentLaunchTemplate:
+      Type: AWS::EC2::LaunchTemplate
+      Properties:
+        LaunchTemplateName: "${self:custom.stackName}-launch-template"
+        LaunchTemplateData:
+          TagSpecifications:
+            - ResourceType: instance
+              Tags:
+                - Key: PROJECT
+                  Value: ${file(../config.yml):config.project}
+                - Key: VERSION
+                  Value: ${self:custom.version}
+                - Key: DEVELOPER
+                  Value: ${env:USER}
+                - Key: STAGE
+                  Value: ${self:provider.stage}
+            - ResourceType: volume
+              Tags:
+                - Key: PROJECT
+                  Value: ${file(../config.yml):config.project}
+                - Key: VERSION
+                  Value: ${self:custom.version}
+                - Key: DEVELOPER
+                  Value: ${env:USER}
+                - Key: STAGE
+                  Value: ${self:provider.stage}
+
     ComputeAlignmentEnv:
       Type: AWS::Batch::ComputeEnvironment
       Properties:
@@ -70,7 +97,9 @@ resources:
             - !ImportValue 'janelia-neuronbridge-vpc-shared-AppSecurityGroupId'
           Ec2KeyPair: ${self:custom.sshKeyPairName}
           InstanceRole: ecsInstanceRole
-          Tags: ${self:provider.stackTags}
+          LaunchTemplate:
+            LaunchTemplateId: !Ref AlignmentLaunchTemplate
+            Version: $Latest
 
     ComputeAlignmentJobQueue:
       Type: AWS::Batch::JobQueue


### PR DESCRIPTION
## Problem

AWS Batch `ComputeResources.Tags` only applies to EC2 instances, not attached
EBS volumes. This causes untagged volumes which breaks cost tracking.

**Example:**
- Volume: `vol-096ac87ce5ec41606` - No tags
- Instance: `i-09cee327cbc3496ee` - Tagged correctly

## Solution

Add an EC2 Launch Template with `TagSpecifications` that explicitly tags both
`instance` and `volume` resource types at creation time.

## Changes

1. **Add** `AlignmentLaunchTemplate` resource
   - Uses `TagSpecifications` to tag both `instance` and `volume` resource types

2. **Update** `ComputeAlignmentEnv`
   - Add `LaunchTemplate` reference
   - Remove `Tags` property (now handled by launch template)

## Tags Applied (to both instances AND volumes)

| Tag | Source |
|-----|--------|
| PROJECT | `config.yml` |
| VERSION | `config.yml` |
| DEVELOPER | `$USER` env var |
| STAGE | `provider.stage` |

These match the existing `stackTags` exactly, preserving cost tracking continuity.

## Testing

After deployment:
1. Trigger an alignment job
2. Check the spawned EC2 instance tags (should be unchanged)
3. Check the attached EBS volume tags (should now have PROJECT, VERSION, etc.)

## References

- [AWS Batch Launch Template support](https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html)
- [EC2 TagSpecifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html)